### PR TITLE
Add Mend Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["pypi"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Python dependencies (non-major)"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Docker base images (non-major)"
+    }
+  ],
+  "pip_requirements": {
+    "fileMatch": ["(^|/)requirements.*\\.txt$"]
+  },
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 10,
+  "schedule": [
+    "before 6am on Monday"
+  ],
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true
+}


### PR DESCRIPTION
Configure Renovate to automatically manage Python and Docker dependencies:
- Group non-major updates for easier review
- Schedule updates for Monday mornings
- Enable dependency dashboard for tracking
- Set reasonable rate limits to avoid PR spam