### PR TITLE
Fix Docker build GitHub Action manifest export

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -61,7 +61,7 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/super-pal-image.tar
+          outputs: type=oci,dest=/tmp/super-pal-image.tar
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4
@@ -122,7 +122,7 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/spin-the-wheel-image.tar
+          outputs: type=oci,dest=/tmp/spin-the-wheel-image.tar
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Changed output type from 'docker' to 'oci' for both super-pal and spin-the-wheel builds. The docker exporter doesn't support manifest lists needed for multi-platform builds, but the OCI exporter does.

This resolves the error:
"docker exporter does not support exporting manifest lists, use the oci exporter instead"